### PR TITLE
update install.bash to install gflags from source

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -67,12 +67,14 @@ install_routine()
     install_pcl
     install_geographiclib
     install_gtsam
-    # install_libwave
-    # install_gflags
-    install_gflags_from_source
+    install_gflags
     install_catch2
     install_json
     install_ladybug_sdk
+
+    # Optional Installs:
+    # install_gflags_from_source
+    # install_libwave
 
     if [[ $1 = 'robot' ]]; then
         echo 'Installing drivers for robot'


### PR DESCRIPTION
It is necessary to install gflags from source rather than via apt-get in order for ros-cartographer to compile. 