### PR TITLE
Update README.md

### DIFF
--- a/inspection_tools/rosbag_tools/README.md
+++ b/inspection_tools/rosbag_tools/README.md
@@ -17,7 +17,7 @@ This tool maintains the indexed times of all messages and ensures *sensor_msgs/P
 
 Run the main exectuble as follows:
 
-`cd catkin_ws/build/unpack_velodyne_scans` \
+`cd catkin_ws/build/rosbag_tools` \
 `./unpack_velodyne_scans_main [args]`
 
 For information on `[args]`, run: `./unpack_velodyne_scans_main --help`


### PR DESCRIPTION
update to reflect installation destination of unpack_velodyne_scans_main. Not aloud to merge directly into master/main